### PR TITLE
Feature/api endpoint as credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+ocf-scheduler-broker
 
 # Test binary, built with `go test -c`
 *.test
@@ -13,3 +14,7 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Temp files
+*~
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+# This how we want to name the binary output
+BINARY=ocf-scheduler-broker
+
+# These are the values we want to pass for VERSION and BUILD
+# git tag 1.0.1
+# git commit -am "One more change after the tags"
+VERSION=`./scripts/genver`
+BUILD=`date +%FT%T%z`
+PACKAGE="github.com/starkandwayne/ocf-scheduler-broker"
+TARGET="builds/${BINARY}-${VERSION}"
+PREFIX="${TARGET}/${BINARY}-${VERSION}"
+TESTFILES=`go list ./... | grep -v /vendor/`
+
+# Setup the -ldflags option for go build here, interpolate the variable values
+LDFLAGS=-ldflags "-w -s \
+				-extldflags '-static'"
+
+# Build for the current platform
+all: clean build
+
+# Build a new release
+release: distclean distbuild linux
+
+# Builds the project
+build:
+	go build ${LDFLAGS} -o ${BINARY} ${PACKAGE}
+
+cli:
+	go build ${LDFLAGS} -o sch github.com/starkandwayne/scheduler-for-ocf/cmd/cli
+
+
+# Builds the project for all possible platforms
+distbuild:
+	mkdir -p ${TARGET}
+
+# Installs our project: copies binaries
+install:
+	go install ${LDFLAGS}
+
+# Cleans our project: deletes binaries
+clean:
+	rm -rf ${BINARY}
+
+# Cleans release files
+distclean:
+	rm -rf ${TARGET}
+
+test:
+	./scripts/blanket
+
+linux:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o ${TARGET}/${BINARY}-linux-amd64 ${PACKAGE}
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build ${LDFLAGS} -o ${TARGET}/${BINARY}-linux-arm ${PACKAGE}

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"code.cloudfoundry.org/lager"
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
+
+	"github.com/starkandwayne/ocf-scheduler-broker/util"
 )
 
 type SchedulerBroker struct {
@@ -28,19 +29,9 @@ type Config struct {
 	Free           bool
 }
 
-func envOr(key string, defaultValue string) string {
-	value := os.Getenv(key)
-
-	if len(value) == 0 {
-		return defaultValue
-	}
-
-	return value
-}
-
 func NewSchedulerImpl(logger lager.Logger) (broker *SchedulerBroker) {
 	credentials := map[string]interface{}{}
-	credentials["api_endpoint"] = envOr("SCHEDULER_URL", "http://localhost:8000")
+	credentials["api_endpoint"] = util.EnvOr("SCHEDULER_URL", "http://localhost:8000")
 
 	return &SchedulerBroker{
 		Logger:    logger,

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"code.cloudfoundry.org/lager"
 	brokerapi "github.com/pivotal-cf/brokerapi/domain"
@@ -27,11 +28,19 @@ type Config struct {
 	Free           bool
 }
 
+func envOr(key string, defaultValue string) string {
+	value := os.Getenv(key)
+
+	if len(value) == 0 {
+		return defaultValue
+	}
+
+	return value
+}
+
 func NewSchedulerImpl(logger lager.Logger) (broker *SchedulerBroker) {
 	credentials := map[string]interface{}{}
-	credentials["credentials1"] = "example-credentials"
-	credentials["credentials2"] = "More example-credentials"
-	fmt.Printf("Credentials: %v\n", credentials)
+	credentials["api_endpoint"] = envOr("SCHEDULER_URL", "http://localhost:8000")
 
 	return &SchedulerBroker{
 		Logger:    logger,

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,5 @@
-module example.com
+module github.com/starkandwayne/ocf-scheduler-broker
+
 go 1.17
 
 require (

--- a/main.go
+++ b/main.go
@@ -6,8 +6,10 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/lager"
-	"example.com/broker"
 	"github.com/pivotal-cf/brokerapi"
+
+	"github.com/starkandwayne/ocf-scheduler-broker/broker"
+	"github.com/starkandwayne/ocf-scheduler-broker/util"
 )
 
 func statusAPI(w http.ResponseWriter, r *http.Request) {
@@ -21,8 +23,8 @@ func main() {
 	servicebroker := broker.NewSchedulerImpl(logger)
 
 	brokerCredentials := brokerapi.BrokerCredentials{
-		Username: "admin",
-		Password: "Test1234",
+		Username: util.EnvOr("AUTH_USER", "admin"),
+		Password: util.EnvOr("AUTH_PASSWORD", "Test1234"),
 	}
 
 	brokerAPI := brokerapi.New(servicebroker, logger, brokerCredentials)
@@ -31,10 +33,7 @@ func main() {
 
 	http.Handle("/", brokerAPI)
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "3000"
-	}
+	port := util.EnvOr("PORT", "3000")
 
 	fmt.Println("\n\nStarting OCF Scheduler Service broker on 0.0.0.0:" + port)
 	logger.Fatal("http-listen", http.ListenAndServe("0.0.0.0:"+port, nil))

--- a/scripts/blanket
+++ b/scripts/blanket
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+append() {
+  local original="${1}"
+  local addition="${2}"
+  local output=""
+
+  if [ -n "${original}" ]
+  then
+    output="${original},${addition}"
+  else
+    output="${addition}"
+  fi
+
+  echo -n "${output}"
+}
+
+coverpkg() {
+  local output=""
+
+  for package in cf cmd combined core cron http logger postgres workflows
+  do
+    if [ -d "./${package}" ]
+    then
+      output=$(append "${output}" "./${package}"...)
+    fi
+  done
+
+  if [ -z "${output}" ]
+  then
+    output="./..."
+  fi
+
+  echo -n "${output}"
+}
+
+generate() {
+  local scope="${1}"
+  local unit=""
+  local integration=""
+
+  case "${scope}" in
+    "integration" | "features" | "outside" )
+      echo "INTEGRATION TESTS ONLY"
+      integration="1"
+    ;;
+
+    "unit" | "inside" )
+      echo "UNIT TESTS ONLY"
+      unit="1"
+    ;;
+
+    * )
+      echo "ALL TESTS"
+      unit="1"
+      integration="1"
+    ;;
+
+  esac
+
+  INTEGRATION="${integration}" UNIT="${unit}" go test -coverprofile=coverage.out -count=1 -v -coverpkg=$(coverpkg) $(go list ./... | grep -v /vendor/)
+}
+
+total() {
+  echo
+  echo -n "TOTAL TEST COVERAGE: "
+  go tool cover -func=coverage.out | grep 'total:' | awk '{print $NF}'
+}
+
+display() {
+  local via="${1}"
+
+  go tool cover -${via}=coverage.out
+}
+
+view() {
+  local via="${1}"
+  local base="go tool cover"
+  local target="=coverage.out"
+
+  case "${via}" in
+    "browser" | "html" )
+      display html
+      ;;
+
+    "terminal" | "func" )
+      echo
+      display func
+      ;;
+
+    * )
+      return 0
+      ;;
+  esac
+}
+
+generate ${2} && view ${1} && total

--- a/scripts/genver
+++ b/scripts/genver
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+ver=$(git describe --tags 2>/dev/null | cut -d '-' -f 1 | head -n 1)
+
+if [ -z "${ver}" ]
+then
+  echo "v0.0.0"
+else
+  echo "${ver}"
+fi

--- a/util/env-or.go
+++ b/util/env-or.go
@@ -1,0 +1,13 @@
+package util
+
+import "os"
+
+func EnvOr(key string, defaultValue string) string {
+	value := os.Getenv(key)
+
+	if len(value) == 0 {
+		return defaultValue
+	}
+
+	return value
+}


### PR DESCRIPTION
Reqeusts that return a `credentials` blob now include an `api_endpoint` field that points the requester to the ocf-scheduler API in use on the foundation.

This is configured with the `SCHEDULER_URL` environment variable, and if this is not set, it defaults to `http://localhost:8000`.

***NOTE***: I've made this PR against the `develop` branch, just to keep with my flow. We should either retarget this PR or make develop the default branch for the repo ;)